### PR TITLE
Add DynamicVolBlock type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,7 +434,7 @@ impl<T> PartialEq for DynamicVolBlock<T> {
 impl<T> Eq for DynamicVolBlock<T> {}
 impl<T> core::fmt::Debug for DynamicVolBlock<T> {
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    write!(f, "VolBlock({:p}, count={})", self.vol_address.address.get() as *mut T, self.count)
+    write!(f, "DynamicVolBlock({:p}, count={})", self.vol_address.address.get() as *mut T, self.count)
   }
 }
 impl<T> DynamicVolBlock<T> {

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -464,13 +464,7 @@ impl<T, const STRIDE: usize> Iterator for ROVolStridingIter<T, STRIDE> {
   #[inline(always)]
   fn last(self) -> Option<Self::Item> {
     if self.slots_remaining > 0 {
-      Some(unsafe {
-        self
-          .vol_address
-          .cast::<u8>()
-          .offset((STRIDE * self.slots_remaining) as isize)
-          .cast::<T>()
-      })
+      Some(unsafe { self.vol_address.cast::<u8>().offset((STRIDE * self.slots_remaining) as isize).cast::<T>() })
     } else {
       None
     }

--- a/src/write_only.rs
+++ b/src/write_only.rs
@@ -452,13 +452,7 @@ impl<T, const STRIDE: usize> Iterator for WOVolStridingIter<T, STRIDE> {
   #[inline(always)]
   fn last(self) -> Option<Self::Item> {
     if self.slots_remaining > 0 {
-      Some(unsafe {
-        self
-          .vol_address
-          .cast::<u8>()
-          .offset((STRIDE * self.slots_remaining) as isize)
-          .cast::<T>()
-      })
+      Some(unsafe { self.vol_address.cast::<u8>().offset((STRIDE * self.slots_remaining) as isize).cast::<T>() })
     } else {
       None
     }

--- a/tests/test_dynamicvolblock.rs
+++ b/tests/test_dynamicvolblock.rs
@@ -1,0 +1,34 @@
+use voladdress::DynamicVolBlock;
+
+#[test]
+fn test_iter() {
+  let dummy: DynamicVolBlock<i32> = unsafe { DynamicVolBlock::new(4, 256) };
+  let i = dummy.iter();
+  let len = dummy.len();
+  assert_eq!(i.size_hint(), (len, Some(len)));
+  assert_eq!(i.count(), len);
+}
+
+#[test]
+fn test_indexing_styles() {
+  let dummy: DynamicVolBlock<i32> = unsafe { DynamicVolBlock::new(4, 256) };
+  let a0 = unsafe { dummy.index_unchecked(0) };
+  let b0 = dummy.index(0);
+  assert_eq!(a0, b0);
+
+  let a1 = unsafe { a0.offset(1) };
+  let b1 = dummy.index(1);
+  assert_eq!(a1, b1);
+
+  for i in 0..dummy.len() {
+    assert_eq!(dummy.get(i).unwrap(), dummy.index(i));
+  }
+  assert!(dummy.get(dummy.len()).is_none());
+}
+
+#[test]
+#[should_panic]
+fn test_index_panic() {
+  let dummy: DynamicVolBlock<i32> = unsafe { DynamicVolBlock::new(4, 256) };
+  dummy.index(dummy.len());
+}


### PR DESCRIPTION
This PR adds a `DynamicVolBlock` type, identical to the VolBlock type except for the fact that the size is specified as a param to `::new()` instead of as a constant value. This makes it possible to create volatile address blocks at runtime instead of compile-time (e.g.: for hardware like NvMe, where the number of I/O queue entries cannot be known at compile-time).