### PR TITLE
Add VolAddress::update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,17 @@ impl<T> VolAddress<T> {
   pub fn write(self, val: T) {
     unsafe { (self.address.get() as *mut T).write_volatile(val) }
   }
+
+  /// Volatile reads a value out of the address, passes it through the given
+  /// function, then volatile writes it back to the address.
+  #[inline(always)]
+  pub fn update<F>(self, func: F)
+  where
+    F: Fn(T) -> T,
+    T: Copy,
+  {
+    self.write(func(self.read()))
+  }
 }
 
 /// A block of addresses all in a row.


### PR DESCRIPTION
This is a convenience method.

Before:
```rust
const REG_DISPCNT: VolAddress<Control> = unsafe { VolAddress::new(0x04_000_000) };

REG_DISPCNT.write(REG_DISPCNT.read()
    .with_mode(Mode::Bitmap0)
    .with_background_layer_2_enabled(true)
    .with_screen_enabled(true));
```

After:
```rust
const REG_DISPCNT: VolAddress<Control> = unsafe { VolAddress::new(0x04_000_000) };

REG_DISPCNT.update(|reg| reg
    .with_mode(Mode::Bitmap0)
    .with_background_layer_2_enabled(true)
    .with_screen_enabled(true));
```